### PR TITLE
Allow string or ObjectIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .meteor/local
 .meteor/meteorite
+.npm

--- a/Schema.js
+++ b/Schema.js
@@ -1,8 +1,13 @@
+import SimpleSchema from 'simpl-schema'
+import {Mongo} from 'meteor/mongo'
+
 Shuttler.Ref.Schema = new SimpleSchema({
 	collection: {
-		type: String
+		type: String,
+		optional: true
 	},
-	id: {
-		type: String
-	}
+	id: SimpleSchema.oneOf(String, {
+		type: Mongo.ObjectID,
+		blackbox: true
+	})
 });

--- a/isRef.js
+++ b/isRef.js
@@ -1,3 +1,5 @@
-Shuttler.isRef = function(ref) {
-	return typeof(ref) == 'object' && typeof(ref.id) == 'string' && (!('collection' in ref) || typeof(ref.collection) == 'string');
+Shuttler.isRef = function (ref) {
+	const validationContext = Shuttler.Ref.Schema.newContext()
+	validationContext.validate(ref)
+	return validationContext.isValid()
 };

--- a/isRef.test.js
+++ b/isRef.test.js
@@ -1,0 +1,19 @@
+import {Tinytest} from 'meteor/tinytest'
+
+Tinytest.add('shuttler:ref - Shutter.isRef - accepts string IDs', test => {
+	test.isTrue(Shuttler.isRef({id: 'asdf'}))
+})
+
+Tinytest.add('shuttler:ref - Shutter.isRef - accepts Mongo.ObjectID IDs', test => {
+	test.isTrue(Shuttler.isRef({
+		id: new Mongo.ObjectID()
+	}))
+})
+
+Tinytest.add('shuttler:ref - Shutter.isRef - accepts an optional collection name', test => {
+	test.isTrue(Shuttler.isRef({id: 'asdf', collection: 'foo'}))
+	test.isTrue(Shuttler.isRef({
+		id: new Mongo.ObjectID(),
+		collection: 'bar'
+	}))
+})

--- a/package.js
+++ b/package.js
@@ -1,18 +1,18 @@
 Package.describe({
   name: 'shuttler:ref',
-  version: '0.0.5',
+  version: '0.0.6',
   summary: 'Adds `Ref` helper to all documents in all collections.',
   git: 'https://github.com/meteor-shuttler/ref',
   documentation: 'README.md'
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom('1.2.1');
+	api.versionsFrom('1.4.4.1');
   
   api.use('mongo');
   api.use('ecmascript');
   
-  api.use('aldeed:simple-schema@1.5.1');
+  // api.use('aldeed:simple-schema@1.5.1');
   api.use('dburles:collection-helpers@1.0.4');
   api.use('lai:collection-extensions@0.2.1');
   api.use('shuttler:namespace@0.0.0');
@@ -24,4 +24,18 @@ Package.onUse(function(api) {
   api.addFiles('Schema.js');
   
   api.export('Shuttler');
+});
+
+Package.onTest(function(api) {
+
+  api.use('mongo');
+  api.use('ecmascript');
+  api.use('shuttler:ref');
+
+  api.use('tinytest');
+  api.addFiles('isRef.test.js');
+})
+
+Npm.depends({
+	'simpl-schema': '0.1.1'
 });


### PR DESCRIPTION
The latest version of SimpleSchema supports validating a field against a
list of types via `SimpleSchema.oneOf`. I've updated
`Shuttler.Ref.Schema` to treat an ID as either a string or a
`Mongo.ObjectID`. I've also updated `Shuttler.isRef` to use the
SimpleSchema validation. Collection names in the schema are also
optional, as `Shuttler.isRef` always considered them optional anyways.